### PR TITLE
Specify a generic parameter for the type of location.

### DIFF
--- a/AlarmingTrafficWP8/Messages/LocationSelectedMessage.cs
+++ b/AlarmingTrafficWP8/Messages/LocationSelectedMessage.cs
@@ -21,9 +21,9 @@ namespace AlarmingTrafficWP8.Messages
 
 
         
-        public Model.LocationUS Location { get; set; }
+        public Model.Location Location { get; set; }
 
-        public LocationSelectedMessage(Model.LocationUS location)
+        public LocationSelectedMessage(Model.Location location)
         {
             Location = location;
         }

--- a/AlarmingTrafficWP8/Service/ILocationDataService.cs
+++ b/AlarmingTrafficWP8/Service/ILocationDataService.cs
@@ -8,7 +8,7 @@ namespace AlarmingTrafficWP8.Service
     public interface ILocationDataService
     {
         Task SaveLocation<T>(T newLocation);
-        Task<ObservableCollection<LocationUS>> LoadLocations();
+        Task<List<Location>> LoadLocations();
         Task UpdateLocation<T>(T selectedLocation);
         Task DeleteLocation<T>(T selectedLocation);
     }

--- a/AlarmingTrafficWP8/Service/LocationDataService.cs
+++ b/AlarmingTrafficWP8/Service/LocationDataService.cs
@@ -11,17 +11,15 @@ namespace AlarmingTrafficWP8.Service
 {
     public class LocationDataService : ILocationDataService
     {
-        private ObservableCollection<LocationUS> _locations = null; // new ObservableCollection<Location>();
-
         public async Task SaveLocation<T>(T newLocationUS)
         {
             await App.Connection.InsertAsync(newLocationUS);
         }
 
         // Must be upgraded to return any/all Location Data
-        public async Task<ObservableCollection<LocationUS>> LoadLocations()
+        public async Task<List<Location>> LoadLocations()
         {
-            _locations = new ObservableCollection<LocationUS>();
+            var locations = new List<Location>();
 
             //ObservableCollection<T> _locations = new ObservableCollection<T>();            
             //List<object> tableList = null;
@@ -67,18 +65,18 @@ namespace AlarmingTrafficWP8.Service
 
                 foreach (var item in list)
                 {
-                    this._locations.Add(item);
+                    locations.Add(item);
                 }
             }
             catch (Exception exc)
             {
                 MessageBox.Show(exc.ToString());
 
-                _locations = null;
+                locations = null;
             }
 
 
-            return _locations;
+            return locations;
         }
 
         public async Task UpdateLocation<T>(T selectedLocation)

--- a/AlarmingTrafficWP8/Service/LocationDesignDataService.cs
+++ b/AlarmingTrafficWP8/Service/LocationDesignDataService.cs
@@ -1,4 +1,5 @@
 ﻿using AlarmingTrafficWP8.Model;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
@@ -12,9 +13,9 @@ namespace AlarmingTrafficWP8.Service
             await App.Connection.InsertAsync(newLocation);
         }
                 
-         public async Task<ObservableCollection<LocationUS>> LoadLocations() //Task<ObservableCollection<LocationUS>> LoadLocations()
+         public async Task<List<Location>> LoadLocations() //Task<ObservableCollection<LocationUS>> LoadLocations()
         {
-            var result = new ObservableCollection<LocationUS>();
+            var result = new List<Location>();
 
             for (int i = 0; i < 4; i++)
             {

--- a/AlarmingTrafficWP8/ViewModel/LocationEditViewModel.cs
+++ b/AlarmingTrafficWP8/ViewModel/LocationEditViewModel.cs
@@ -35,14 +35,14 @@ namespace AlarmingTrafficWP8.ViewModel
         private readonly ILocationDataService _locationDataService;
         private readonly INavigationService _navigationService;
 
-        private LocationUS _selectedLocation;
+        private Location _selectedLocation;
         //private GeoCoordinate geo1 = null;
         private GeoCoordinate mapCenter = new GeoCoordinate(40.712923, -74.013292);
 
         /// <summary>
         /// Sets and gets the SelectedLocation property.
         /// </summary>
-        public LocationUS SelectedLocation
+        public Location SelectedLocation
         {
             get
             {

--- a/AlarmingTrafficWP8/ViewModel/ViewModelLocator.cs
+++ b/AlarmingTrafficWP8/ViewModel/ViewModelLocator.cs
@@ -77,17 +77,17 @@ namespace AlarmingTrafficWP8.ViewModel
 
 
             //SimpleIoc.Default.Register<MainViewModel>();
-            SimpleIoc.Default.Register<LocationViewModel>();
+            SimpleIoc.Default.Register<LocationViewModel<LocationUS>>();
             SimpleIoc.Default.Register<LocationEditViewModel>(true);
             //SimpleIoc.Default.Register<LocationEditViewModel>();
             SimpleIoc.Default.Register<RouteViewModel>();
             //SimpleIoc.Default.Register<RouteEditViewModel>(true);
         }
 
-        public LocationViewModel LocationViewModel
+        public LocationViewModel<LocationUS> LocationViewModel
         {
             //get { return SimpleIoc.Default.GetInstance<LocationViewModel>(); }
-            get { return ServiceLocator.Current.GetInstance<LocationViewModel>(); }
+            get { return ServiceLocator.Current.GetInstance<LocationViewModel<LocationUS>>(); }
         }
 
         public LocationEditViewModel LocationEditViewModel


### PR DESCRIPTION
I'm not entirely sure that generics are the right way to solve this problem. But let's start there and see where it goes.

I added the generic parameter to the view model class. The compiler then told me that it could not create a new instance of the generic type, so I added the "new()" constraint. Then so that you can treat a TLocation as a kind of Location, I added the "Location" constraint as well. Now this view model can only be used with classes that inherit Location.

I also changed the way that the ObservableCollection is constructed. The service should not be responsible for creating the ObservableCollection. That is the job of the view model. The service returns a list of Locations. This list could contain any derived class. Then, I changed the ObservableCollection property in the view model to be read only. The view model should never change the collection itself, only the objects that the collection contains.

I also made the Locations property read-only. You should never pull the collection rug out from under the view model. You should only add and remove items in the given collection.

Right now only the LocationUS view model is registered in the container. Other types of location view model should be registered as well. The property name should be changed to represent the country.

Finally, I changed the message to accept any kind of Location.
